### PR TITLE
Fix parsing of >2 collapsed commands

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -28,34 +28,18 @@ class SvgParserDefinition extends SvgGrammarDefinition {
 
   @override
   moveTo() => super.moveTo().map((List result) {
-    // Single move.
-    if (result[2] is Point) {
-      Point point = result[2];
-      return [new SvgPathMoveSegment(point.x, point.y)];
-    }
-
-    // Multiple move.
-    if (result[2] is Iterable) {
-      return (result[2] as Iterable).where((e) => e is Point).map((Point p) {
-        return new SvgPathMoveSegment(p.x, p.y);
-      });
-    }
+    return _argsParser(result[2], 1).map((List args) {
+      Point point = args[0];
+      return new SvgPathMoveSegment(point.x, point.y);
+    });
   });
 
   @override
   lineTo() => super.lineTo().map((List result) {
-    // Single line.
-    if (result[2] is Point) {
-      Point point = result[2];
-      return [new SvgPathLineSegment(point.x, point.y)];
-    }
-
-    // Multiple lines.
-    if (result[2] is Iterable) {
-      return (result[2] as Iterable).where((e) => e is Point).map((Point p) {
-        return new SvgPathLineSegment(p.x, p.y);
-      }).toList(growable: false);
-    }
+    return _argsParser(result[2], 1).map((List args) {
+      Point point = args[0];
+      return new SvgPathLineSegment(point.x, point.y);
+    });
   });
 
   @override
@@ -87,5 +71,25 @@ class SvgParserDefinition extends SvgGrammarDefinition {
   @override
   fractionalConstant() {
     return super.fractionalConstant().flatten().map(double.parse);
+  }
+
+  List _argsParser(seq, num argCount) {
+    Iterable it = seq is Iterable ? seq : [seq];
+
+    var arr = [];
+
+    while (it != null) {
+      arr.add(it.take(argCount).toList(growable: false));
+
+      var next = it.skip(argCount + 1);
+      if (next.isEmpty) {
+        it = null;
+      } else {
+        var seq = next.single;
+        it = seq is Iterable ? seq : [seq];
+      }
+    }
+
+    return arr;
   }
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -8,7 +8,7 @@ import 'package:svg/src/parser.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('SvgParserDefinitiin', () {
+  group('SvgParserDefinition', () {
     final definition = const SvgParserDefinition();
 
     group('Fractional constants', () {
@@ -110,9 +110,10 @@ void main() {
 
       test('can parse multiple line values', () {
         expect(
-            parseLine('l1,1,2,2').value, [
+            parseLine('l1,1,2,2,3,3').value, [
               const SvgPathLineSegment(1, 1),
-              const SvgPathLineSegment(2, 2)
+              const SvgPathLineSegment(2, 2),
+              const SvgPathLineSegment(3, 3)
             ]);
       });
     });
@@ -130,10 +131,11 @@ void main() {
 
       test('can parse followed by additional moves', () {
         expect(
-            parseMove('m0,0,5,5').value,
+            parseMove('m0,0,5,5,10,10').value,
             [
               const SvgPathMoveSegment(0, 0),
-              const SvgPathMoveSegment(5, 5)
+              const SvgPathMoveSegment(5, 5),
+              const SvgPathMoveSegment(10, 10)
             ]);
       });
     });


### PR DESCRIPTION
The parsing SVG collapsed commands (eg. `L10,10 20,20 30,30`) only worked for 1 or two commands. For three or more commands it broke down.