### PR TITLE
Remove whitespaces from parsed results

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -10,7 +10,10 @@ class SvgParserDefinition extends SvgGrammarDefinition {
   const SvgParserDefinition();
 
   @override
-  svgPath() => super.svgPath().map((Iterable r) => r.toList(growable: false));
+  svgPath() => super.svgPath().map((result) {
+    result = result.map((r) => r.where((p) => p is SvgPathSegment));
+    return result.toList(growable: false);
+  });
 
   @override
   moveToDrawToCommandGroup() => super.moveToDrawToCommandGroup().map((result) {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -218,7 +218,7 @@ void main() {
   });
 
   test('parseSvgPath works as intended', () {
-    expect(svg.parseSvgPath('M0,15,L15,15L7.5,0z'), const [
+    expect(svg.parseSvgPath(' M0,15,L15,15 L 7.5,0z '), const [
       const SvgPathMoveSegment(0, 15),
       const SvgPathLineSegment(15, 15),
       const SvgPathLineSegment(7.5, 0),


### PR DESCRIPTION
The parser was more than happy to return whitespaces from the path data. This filters out everything that isn't a decendant of `SvgPathSegment`